### PR TITLE
UI v2: site header, starscape hero, dark mode, real video thumbnails

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 /* ── DESIGN TOKENS ──────────────────────────────────────── */
 :root {
   --bg:           #FEFBF7;
+  --bg-raw:       254, 251, 247;
   --card:         #FFFFFF;
   --border:       #EDE4DA;
   --text:         #231D18;
@@ -23,6 +24,18 @@
   --radius-md:  6px;
   --radius-lg:  10px;
   --radius-xl:  16px;
+}
+
+/* ── DARK MODE ──────────────────────────────────────────── */
+[data-theme="dark"] {
+  --bg:           #0D0A08;
+  --bg-raw:       13, 10, 8;
+  --card:         #1A1512;
+  --border:       #2E2520;
+  --text:         #F5EEE8;
+  --sub:          #7A6E68;
+  --accent-light: rgba(192, 72, 106, 0.15);
+  --accent-ring:  rgba(192, 72, 106, 0.28);
 }
 
 /* ── BASE ───────────────────────────────────────────────── */
@@ -121,8 +134,8 @@ button { -webkit-tap-highlight-color: transparent; cursor: pointer; }
 
 /* Icon button */
 .icon-btn {
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   border-radius: var(--radius-md);
   border: none;
   background: transparent;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/components/AuthProvider';
+import { ThemeProvider } from '@/components/ThemeProvider';
 
 export const metadata: Metadata = {
   title: 'Red Rose Gaming 🌹',
@@ -11,9 +12,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            {children}
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,16 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { Nav } from '@/components/Nav';
+import { SiteHeader } from '@/components/SiteHeader';
+import { Footer } from '@/components/Footer';
+import { StarscapeHero } from '@/components/StarscapeHero';
 import { VideoCard } from '@/components/VideoCard';
 import { UploadModal } from '@/components/UploadModal';
 import { Toast } from '@/components/Toast';
 import { subscribeToVideos } from '@/lib/firebase/videos';
 import type { Video, GameTag } from '@/lib/types';
 
-const FILTERS: (GameTag | 'All')[] = ['All', 'Dress to Impress', 'Brookhaven', '99 Nights'];
-
-// Sparkle dot positions (deterministic — avoids SSR mismatch)
-const SPARKLES = [
-  { size: 5, opacity: 0.5, top: '22%', left: '12%', delay: 0 },
-  { size: 3, opacity: 0.6, top: '65%', left: '18%', delay: 0.7 },
-  { size: 6, opacity: 0.35, top: '30%', left: '78%', delay: 1.2 },
-  { size: 4, opacity: 0.5, top: '70%', left: '72%', delay: 0.4 },
-  { size: 3, opacity: 0.45, top: '15%', left: '50%', delay: 1.8 },
-  { size: 5, opacity: 0.4, top: '78%', left: '42%', delay: 0.9 },
-  { size: 3, opacity: 0.4, top: '50%', left: '8%',  delay: 2.1 },
-  { size: 4, opacity: 0.3, top: '20%', left: '88%', delay: 0.3 },
-  { size: 6, opacity: 0.3, top: '88%', left: '60%', delay: 1.5 },
-  { size: 3, opacity: 0.5, top: '42%', left: '95%', delay: 0.6 },
-];
+const FILTERS: (GameTag | 'All')[] = ['All', 'Dress to Impress', 'Brookhaven', '99 Nights', 'Just Chatting', 'Other Roblox'];
 
 export default function ChannelPage() {
   const [videos, setVideos] = useState<Video[]>([]);
@@ -58,102 +46,47 @@ export default function ChannelPage() {
 
   return (
     <>
-      <Nav onUpload={() => setShowUpload(true)} />
+      <SiteHeader
+        videoCount={videos.length}
+        totalViews={totalViews}
+        onUpload={() => setShowUpload(true)}
+      />
 
-      {/* Hero */}
-      <div style={{
-        position: 'relative', height: 280, overflow: 'hidden',
-        borderBottom: '1px solid var(--border)',
-        background: 'linear-gradient(135deg, #FDF0F3 0%, #F5EBF7 50%, #EEF2FD 100%)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-      }}>
-        {/* Radial glow */}
-        <div style={{
-          position: 'absolute', width: 500, height: 500,
-          top: '50%', left: '50%', transform: 'translate(-50%,-50%)',
-          background: 'radial-gradient(circle, rgba(192,72,106,0.12) 0%, transparent 65%)',
-          pointerEvents: 'none',
-        }} />
-        {/* Sparkles */}
-        {SPARKLES.map((s, i) => (
-          <div key={i} style={{
-            position: 'absolute', borderRadius: '50%',
-            width: s.size, height: s.size,
-            background: i % 2 === 0 ? 'var(--accent)' : '#B080C0',
-            opacity: s.opacity,
-            top: s.top, left: s.left,
-            animation: `shimmer ${3 + (i % 3) * 0.8}s ${s.delay}s ease-in-out infinite`,
-            pointerEvents: 'none',
-          }} />
-        ))}
-        <div style={{ position: 'relative', zIndex: 5, textAlign: 'center', animation: 'fadeUp 0.8s var(--ease) both' }}>
-          <h1 style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 56, letterSpacing: '-0.02em', lineHeight: 1,
-            color: 'var(--text)', marginBottom: 10,
-          }}>
-            Red Rose Gaming
-          </h1>
-          <p style={{ fontSize: 13, fontWeight: 600, color: 'var(--sub)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>
-            Private Family Channel
-          </p>
-        </div>
-      </div>
-
-      {/* Profile strip */}
-      <div style={{
-        background: 'var(--card)', borderBottom: '1px solid var(--border)',
-        padding: '0 32px 24px',
-        display: 'flex', gap: 20, alignItems: 'flex-end', flexWrap: 'wrap',
-      }}>
-        <div style={{
-          width: 88, height: 88, marginTop: -44, flexShrink: 0,
-          borderRadius: 10, border: '3px solid var(--card)', outline: '2px solid var(--accent)',
-          background: 'linear-gradient(135deg, #F9D0DC, #E8C8F0)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          fontSize: 40, animation: 'pulse-ring 3.5s ease-in-out infinite',
-        }}>
-          🌹
-        </div>
-        <div style={{ paddingTop: 14, flex: 1, minWidth: 180 }}>
-          <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 28, letterSpacing: '-0.01em', marginBottom: 6 }}>
-            Red Rose Gaming
-          </h2>
-          <p style={{ fontSize: 12, fontWeight: 600, color: 'var(--sub)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>
-            {videos.length} {videos.length === 1 ? 'video' : 'videos'} · {totalViews} total views · 🔒 Private
-          </p>
-          <p style={{ fontSize: 14, color: 'var(--sub)', marginTop: 2 }}>Gaming, Roblox &amp; more</p>
-        </div>
-      </div>
+      <StarscapeHero height={300} />
 
       {/* Filter tabs */}
       <div style={{
         background: 'var(--card)', borderBottom: '1px solid var(--border)',
-        padding: '0 32px', display: 'flex', gap: 4, height: 48, alignItems: 'center',
+        padding: '0 24px', display: 'flex', gap: 4, height: 56, alignItems: 'center',
         overflowX: 'auto',
+        // Scroll indicator fade on right
+        maskImage: 'linear-gradient(to right, black 85%, transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to right, black 85%, transparent 100%)',
       }}>
         {FILTERS.map(tag => (
           <button
             key={tag}
             onClick={() => setFilter(tag)}
             style={{
-              padding: '6px 16px', borderRadius: 20, fontSize: 12,
+              padding: '10px 18px', borderRadius: 20, fontSize: 12,
               fontWeight: 600, cursor: 'pointer',
               textTransform: 'uppercase', letterSpacing: '0.06em',
               transition: 'all 0.18s var(--ease)', whiteSpace: 'nowrap',
               border: filter === tag ? '1px solid rgba(192,72,106,0.2)' : '1px solid transparent',
               background: filter === tag ? 'var(--accent-light)' : 'transparent',
               color: filter === tag ? 'var(--accent)' : 'var(--sub)',
-              minHeight: 36,
+              minHeight: 44,
             }}
           >
             {tag}
           </button>
         ))}
+        {/* Spacer so last item clears the mask */}
+        <div style={{ minWidth: 24, flexShrink: 0 }} />
       </div>
 
       {/* Grid */}
-      <div style={{ padding: '32px 32px 64px' }}>
+      <div style={{ padding: '28px 24px 48px' }}>
         {loading ? (
           <div style={{ textAlign: 'center', padding: '64px 0', color: 'var(--sub)' }}>
             Loading videos…
@@ -167,8 +100,8 @@ export default function ChannelPage() {
         ) : (
           <div style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))',
-            gap: 20,
+            gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+            gap: 18,
           }}>
             {filtered.map(v => (
               <VideoCard key={v.id} video={v} onShare={copyLink} />
@@ -176,6 +109,8 @@ export default function ChannelPage() {
           </div>
         )}
       </div>
+
+      <Footer />
 
       {showUpload && (
         <UploadModal

--- a/src/app/watch/[id]/page.tsx
+++ b/src/app/watch/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { use } from 'react';
-import { Nav } from '@/components/Nav';
+import { SiteHeader } from '@/components/SiteHeader';
+import { Footer } from '@/components/Footer';
 import { VideoThumb } from '@/components/VideoThumb';
 import { VideoCard } from '@/components/VideoCard';
 import { CommentSection } from '@/components/CommentSection';
@@ -40,7 +41,6 @@ export default function WatchPage({ params }: PageProps) {
     });
   }, [id, userId]);
 
-  // Related videos (all others)
   useEffect(() => {
     const unsub = subscribeToVideos(vs => {
       setRelated(vs.filter(v => v.id !== id).slice(0, 4));
@@ -48,7 +48,6 @@ export default function WatchPage({ params }: PageProps) {
     return unsub;
   }, [id]);
 
-  // Count view once per session
   useEffect(() => {
     if (video && !viewCounted.current) {
       viewCounted.current = true;
@@ -73,8 +72,9 @@ export default function WatchPage({ params }: PageProps) {
   if (loading) {
     return (
       <>
-        <Nav />
+        <SiteHeader />
         <div style={{ textAlign: 'center', padding: '120px 32px', color: 'var(--sub)' }}>Loading…</div>
+        <Footer />
       </>
     );
   }
@@ -82,26 +82,28 @@ export default function WatchPage({ params }: PageProps) {
   if (!video) {
     return (
       <>
-        <Nav />
+        <SiteHeader />
         <div style={{ textAlign: 'center', padding: '120px 32px' }}>
           <p style={{ color: 'var(--sub)', marginBottom: 16 }}>Video not found.</p>
           <Link href="/" className="btn btn-primary">← Back to channel</Link>
         </div>
+        <Footer />
       </>
     );
   }
 
   return (
     <>
-      <Nav />
+      <SiteHeader />
 
-      <div style={{ maxWidth: 900, margin: '0 auto', padding: '32px 24px 80px' }}>
+      <div style={{ maxWidth: 960, margin: '0 auto', padding: '28px 24px 56px' }}>
         {/* Back link */}
         <Link href="/" style={{
           display: 'inline-flex', alignItems: 'center', gap: 6,
-          fontSize: 12, fontWeight: 600, color: 'var(--sub)',
+          fontSize: 13, fontWeight: 600, color: 'var(--sub)',
           textDecoration: 'none', textTransform: 'uppercase', letterSpacing: '0.07em',
           marginBottom: 24, transition: 'color 0.15s',
+          minHeight: 44, padding: '10px 0',
         }}
         onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent)')}
         onMouseLeave={e => (e.currentTarget.style.color = 'var(--sub)')}
@@ -113,15 +115,14 @@ export default function WatchPage({ params }: PageProps) {
         <div style={{
           width: '100%', borderRadius: 12,
           overflow: 'hidden', border: '1px solid var(--border)',
-          marginBottom: 24,
-          background: '#000',
+          marginBottom: 24, background: '#000',
         }}>
           {video.storageUrl ? (
             <video
               controls
               playsInline
               preload="metadata"
-              style={{ width: '100%', display: 'block', maxHeight: '60vh' }}
+              style={{ width: '100%', display: 'block', maxHeight: '55vh' }}
               src={video.storageUrl}
             />
           ) : (
@@ -148,7 +149,7 @@ export default function WatchPage({ params }: PageProps) {
               {video.views} views · {video.game}
               {video.duration && ` · ${video.duration}`}
             </span>
-            <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ display: 'flex', gap: 10 }}>
               <button
                 onClick={handleLike}
                 className="btn"
@@ -156,12 +157,14 @@ export default function WatchPage({ params }: PageProps) {
                   background: liked ? 'var(--accent)' : 'transparent',
                   border: `1px solid ${liked ? 'var(--accent)' : 'var(--border)'}`,
                   color: liked ? '#fff' : 'var(--text)',
-                  padding: '8px 16px',
+                  padding: '10px 18px', minHeight: 44,
                 }}
               >
                 {liked ? '❤️' : '♡'} {likeCount}
               </button>
-              <button onClick={copyLink} className="btn btn-outline">⎋ Share</button>
+              <button onClick={copyLink} className="btn btn-outline" style={{ minHeight: 44, padding: '10px 18px' }}>
+                ↗ Share
+              </button>
             </div>
           </div>
 
@@ -183,7 +186,7 @@ export default function WatchPage({ params }: PageProps) {
         {related.length > 0 && (
           <div style={{ marginTop: 48 }}>
             <h2 className="section-label" style={{ marginBottom: 16 }}>More videos</h2>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 14 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 16 }}>
               {related.map(v => (
                 <VideoCard key={v.id} video={v} compact />
               ))}
@@ -192,6 +195,7 @@ export default function WatchPage({ params }: PageProps) {
         )}
       </div>
 
+      <Footer />
       <Toast message={toast} />
     </>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from './AuthProvider';
+
+export function Footer() {
+  const { user, signOut } = useAuth();
+
+  return (
+    <footer style={{
+      borderTop: '1px solid var(--border)',
+      background: 'rgba(var(--bg-raw), 0.88)',
+      backdropFilter: 'blur(16px)',
+      WebkitBackdropFilter: 'blur(16px)',
+      padding: '0 24px',
+      height: 60,
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    }}>
+      <Link href="/" style={{
+        fontFamily: 'var(--font-display)',
+        fontSize: 17,
+        color: 'var(--accent)',
+        textDecoration: 'none',
+        display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <span style={{ animation: 'float 4s ease-in-out infinite', display: 'inline-block' }}>🌹</span>
+        Red Rose Gaming
+      </Link>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+        <span style={{ fontSize: 11, color: 'var(--sub)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>
+          🔒 Private family channel
+        </span>
+        {user ? (
+          <button
+            onClick={() => signOut()}
+            style={{
+              fontSize: 12, fontWeight: 600, color: 'var(--sub)',
+              background: 'none', border: 'none', cursor: 'pointer',
+              padding: '10px 0', minHeight: 44,
+              transition: 'color 0.15s',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'var(--sub)')}
+          >
+            Sign out
+          </button>
+        ) : (
+          <Link href="/login" style={{
+            fontSize: 12, fontWeight: 600, color: 'var(--sub)',
+            textDecoration: 'none', padding: '10px 0', minHeight: 44,
+            display: 'inline-flex', alignItems: 'center',
+            transition: 'color 0.15s',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent)')}
+          onMouseLeave={e => (e.currentTarget.style.color = 'var(--sub)')}
+          >
+            Admin →
+          </Link>
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useAuth } from './AuthProvider';
+import { useTheme } from './ThemeProvider';
+
+interface SiteHeaderProps {
+  videoCount?: number;
+  totalViews?: number;
+  onUpload?: () => void;
+}
+
+export function SiteHeader({ videoCount = 0, totalViews = 0, onUpload }: SiteHeaderProps) {
+  const { user, isAdmin, signOut } = useAuth();
+  const { theme, toggle } = useTheme();
+  const [compact, setCompact] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setCompact(window.scrollY > 80);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    await signOut();
+    setSigningOut(false);
+  };
+
+  return (
+    <header style={{
+      position: 'sticky', top: 0, zIndex: 100,
+      background: compact
+        ? 'rgba(var(--bg-raw), 0.92)'
+        : 'rgba(var(--bg-raw), 0.85)',
+      backdropFilter: 'blur(20px)',
+      WebkitBackdropFilter: 'blur(20px)',
+      borderBottom: '1px solid var(--border)',
+      padding: compact ? '0 24px' : '14px 24px',
+      height: compact ? 60 : 84,
+      display: 'flex', alignItems: 'center', gap: 16,
+      transition: 'height 0.3s ease, padding 0.3s ease',
+    }}>
+      {/* Logo — links home */}
+      <Link href="/" style={{ display: 'flex', alignItems: 'center', gap: 14, textDecoration: 'none', flex: 1, minWidth: 0 }}>
+        <div style={{
+          flexShrink: 0,
+          width: compact ? 34 : 52,
+          height: compact ? 34 : 52,
+          borderRadius: compact ? 8 : 12,
+          background: 'linear-gradient(135deg, #F9D0DC, #E8C8F0)',
+          border: `${compact ? 1.5 : 2}px solid var(--accent)`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: compact ? 18 : 28,
+          transition: 'all 0.3s ease',
+        }}>
+          🌹
+        </div>
+
+        <div style={{ minWidth: 0 }}>
+          <h1 style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: compact ? 18 : 24,
+            letterSpacing: '-0.01em',
+            lineHeight: 1.1,
+            color: 'var(--text)',
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            transition: 'font-size 0.3s ease',
+            marginBottom: compact ? 0 : 4,
+          }}>
+            Red Rose Gaming
+          </h1>
+          <div style={{
+            overflow: 'hidden',
+            maxHeight: compact ? 0 : 20,
+            opacity: compact ? 0 : 1,
+            transition: 'max-height 0.3s ease, opacity 0.2s ease',
+          }}>
+            <p style={{ fontSize: 11, fontWeight: 600, color: 'var(--sub)', textTransform: 'uppercase', letterSpacing: '0.08em', whiteSpace: 'nowrap' }}>
+              {videoCount} {videoCount === 1 ? 'video' : 'videos'} · {totalViews} views · 🔒 Private
+            </p>
+          </div>
+        </div>
+      </Link>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+        <button
+          className="icon-btn"
+          onClick={toggle}
+          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          title={theme === 'dark' ? 'Light mode' : 'Dark mode'}
+        >
+          {theme === 'dark' ? '☀️' : '🌙'}
+        </button>
+
+        {isAdmin && onUpload && (
+          <button className="btn btn-primary" onClick={onUpload}>
+            + Upload
+          </button>
+        )}
+
+        {user && (
+          <button
+            className="btn btn-outline"
+            onClick={handleSignOut}
+            disabled={signingOut}
+            style={{ fontSize: 12 }}
+          >
+            {signingOut ? '…' : 'Sign out'}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/StarscapeHero.tsx
+++ b/src/components/StarscapeHero.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTheme } from './ThemeProvider';
+
+const NEON = ['#00CCDD', '#EE00CC', '#8833FF', '#0099EE', '#FF2288', '#CC44AA', '#5500EE', '#00AAFF'];
+
+interface Star {
+  angle: number;
+  pAngle: number;
+  radius: number;
+  pRadius: number;
+  speed: number;
+  twist: number;
+  color: string;
+}
+
+function makeStar(): Star {
+  const angle = Math.random() * Math.PI * 2;
+  const radius = Math.random() * 0.02;
+  return {
+    angle,
+    pAngle: angle,
+    radius,
+    pRadius: radius,
+    speed: 0.003 + Math.random() * 0.007,
+    twist: (Math.random() - 0.5) * 0.01,
+    color: NEON[Math.floor(Math.random() * NEON.length)],
+  };
+}
+
+export function StarscapeHero({ height = 320 }: { height?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const bgSolid = isDark ? '#04020F' : '#FFFFFF';
+  const bgFade  = isDark ? 'rgba(4, 2, 20, 0.20)' : 'rgba(255, 255, 255, 0.22)';
+  const vignette = isDark
+    ? 'radial-gradient(ellipse at center, transparent 30%, rgba(4,2,20,0.65) 100%)'
+    : 'radial-gradient(ellipse at center, transparent 40%, rgba(255,255,255,0.5) 100%)';
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let w = 0;
+    let h = 0;
+
+    const resize = () => {
+      w = canvas.offsetWidth;
+      h = canvas.offsetHeight;
+      canvas.width = w;
+      canvas.height = h;
+      ctx.fillStyle = bgSolid;
+      ctx.fillRect(0, 0, w, h);
+    };
+    resize();
+
+    const NUM = 220;
+    const stars: Star[] = Array.from({ length: NUM }, () => {
+      const s = makeStar();
+      s.radius = Math.random() * 0.9;
+      s.pRadius = s.radius;
+      return s;
+    });
+
+    let animId: number;
+
+    const render = () => {
+      const cx = w / 2;
+      const cy = h / 2;
+      const maxR = Math.sqrt(cx * cx + cy * cy) * 1.15;
+
+      ctx.fillStyle = bgFade;
+      ctx.fillRect(0, 0, w, h);
+
+      for (const s of stars) {
+        s.pAngle = s.angle;
+        s.pRadius = s.radius;
+
+        s.radius += s.speed * (0.4 + s.radius * 2.2);
+        s.angle += s.twist;
+
+        if (s.radius > 1.05) {
+          Object.assign(s, makeStar());
+          continue;
+        }
+
+        const sx = cx + Math.cos(s.angle) * s.radius * maxR;
+        const sy = cy + Math.sin(s.angle) * s.radius * maxR * 0.65;
+        const px = cx + Math.cos(s.pAngle) * s.pRadius * maxR;
+        const py = cy + Math.sin(s.pAngle) * s.pRadius * maxR * 0.65;
+
+        const size = 0.4 + s.radius * 2.8;
+        const alpha = Math.min(1, s.radius * 2.5);
+
+        ctx.save();
+        ctx.globalAlpha = alpha;
+        ctx.strokeStyle = s.color;
+        ctx.lineWidth = size;
+        ctx.shadowColor = s.color;
+        ctx.shadowBlur = size * 5;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(px, py);
+        ctx.lineTo(sx, sy);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      animId = requestAnimationFrame(render);
+    };
+
+    render();
+
+    window.addEventListener('resize', resize);
+    return () => {
+      cancelAnimationFrame(animId);
+      window.removeEventListener('resize', resize);
+    };
+  }, [isDark]); // re-init canvas when theme changes
+
+  return (
+    <div style={{ position: 'relative', height, overflow: 'hidden', background: bgSolid }}>
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', height: '100%', display: 'block' }}
+      />
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: vignette,
+        pointerEvents: 'none',
+      }} />
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, height: 60,
+        background: 'linear-gradient(to bottom, transparent, var(--bg))',
+        pointerEvents: 'none',
+      }} />
+    </div>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const ThemeContext = createContext<{ theme: Theme; toggle: () => void }>({
+  theme: 'light',
+  toggle: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('rrg-theme') as Theme | null;
+    const initial = stored ?? 'light';
+    setTheme(initial);
+    document.documentElement.dataset.theme = initial;
+  }, []);
+
+  const toggle = () => {
+    setTheme(prev => {
+      const next = prev === 'light' ? 'dark' : 'light';
+      localStorage.setItem('rrg-theme', next);
+      document.documentElement.dataset.theme = next;
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -75,7 +75,7 @@ export function VideoCard({ video, compact, onShare }: VideoCardProps) {
               )}
             </span>
 
-            <div style={{ display: 'flex', gap: 2 }}>
+            <div style={{ display: 'flex', gap: 8 }}>
               <button className="icon-btn" onClick={handleLike} title="Like" aria-label="Like">
                 <span style={{
                   fontSize: 16,
@@ -85,8 +85,8 @@ export function VideoCard({ video, compact, onShare }: VideoCardProps) {
                   {liked ? '❤️' : '♡'}
                 </span>
               </button>
-              <button className="icon-btn" onClick={handleShare} title="Share" aria-label="Copy link">
-                ⎋
+              <button className="icon-btn" onClick={handleShare} title="Copy link" aria-label="Copy link">
+                ↗
               </button>
             </div>
           </div>

--- a/src/components/VideoThumb.tsx
+++ b/src/components/VideoThumb.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useRef, useState } from 'react';
 import type { Video } from '@/lib/types';
 import { thumbClass } from '@/lib/types';
 
@@ -17,78 +20,101 @@ interface VideoThumbProps {
 export function VideoThumb({ video, large }: VideoThumbProps) {
   const emoji = GAME_EMOJI[video.game] ?? '🎮';
   const tc = thumbClass(video.game);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [videoReady, setVideoReady] = useState(false);
+
+  const handleMouseEnter = () => {
+    videoRef.current?.play().catch(() => {});
+  };
+
+  const handleMouseLeave = () => {
+    const v = videoRef.current;
+    if (v) { v.pause(); v.currentTime = 0; }
+  };
 
   return (
-    <div style={{
-      width: '100%',
-      aspectRatio: '16 / 9',
-      position: 'relative',
-      overflow: 'hidden',
-      borderRadius: large ? '10px 10px 0 0' : 8,
-      flexShrink: 0,
-    }}>
-      {/* Coloured gradient */}
-      <div className={tc} style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        {/* Subtle radial overlay for depth */}
+    <div
+      style={{
+        width: '100%',
+        aspectRatio: '16 / 9',
+        position: 'relative',
+        overflow: 'hidden',
+        borderRadius: large ? '10px 10px 0 0' : 8,
+        flexShrink: 0,
+      }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {/* Gradient fallback — always visible behind video */}
+      <div className={tc} style={{ position: 'absolute', inset: 0 }}>
         <div style={{
           position: 'absolute', inset: 0,
-          background: 'radial-gradient(circle at center, rgba(255,255,255,0.15) 0%, transparent 65%)',
+          background: 'radial-gradient(circle at center, rgba(255,255,255,0.2) 0%, transparent 65%)',
         }} />
+      </div>
 
-        <span style={{
-          fontSize: large ? 80 : 52,
-          filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.2))',
-          transition: 'transform 0.3s var(--ease)',
-          position: 'relative', zIndex: 1,
-        }}>
-          {emoji}
-        </span>
+      {/* Real video — fades in once metadata is loaded */}
+      {video.storageUrl && (
+        <video
+          ref={videoRef}
+          src={video.storageUrl}
+          muted
+          playsInline
+          preload="metadata"
+          onLoadedMetadata={() => setVideoReady(true)}
+          style={{
+            position: 'absolute', inset: 0,
+            width: '100%', height: '100%',
+            objectFit: 'cover',
+            opacity: videoReady ? 1 : 0,
+            transition: 'opacity 0.4s',
+          }}
+        />
+      )}
 
-        {/* Game tag — top left */}
+      {/* Game tag */}
+      <div style={{
+        position: 'absolute', top: 10, left: 10, zIndex: 10,
+        background: 'rgba(0,0,0,0.48)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        color: 'white',
+        fontSize: large ? 12 : 11,
+        fontWeight: 700,
+        letterSpacing: '0.05em',
+        textTransform: 'uppercase',
+        padding: '4px 10px',
+        borderRadius: 4,
+      }}>
+        {video.game}
+      </div>
+
+      {/* Duration */}
+      {video.duration && (
         <div style={{
-          position: 'absolute', top: 10, left: 10,
-          background: 'rgba(255,255,255,0.22)',
-          backdropFilter: 'blur(8px)',
-          WebkitBackdropFilter: 'blur(8px)',
+          position: 'absolute', bottom: 10, left: 10, zIndex: 10,
+          background: 'rgba(0,0,0,0.55)',
           color: 'white',
-          fontSize: large ? 12 : 11,
-          fontWeight: 700,
-          letterSpacing: '0.05em',
-          textTransform: 'uppercase',
-          padding: '4px 10px',
-          borderRadius: 4,
-          border: '1px solid rgba(255,255,255,0.3)',
+          fontSize: 11, fontWeight: 700, letterSpacing: '0.04em',
+          padding: '3px 8px', borderRadius: 4,
         }}>
-          {video.game}
+          {video.duration}
         </div>
+      )}
 
-        {/* Duration — bottom left */}
-        {video.duration && (
-          <div style={{
-            position: 'absolute', bottom: 10, left: 10,
-            background: 'rgba(0,0,0,0.55)',
-            color: 'white',
-            fontSize: 11, fontWeight: 700, letterSpacing: '0.04em',
-            padding: '3px 8px', borderRadius: 4,
-          }}>
-            {video.duration}
-          </div>
-        )}
-
-        {/* Rose badge — bottom right */}
-        <div style={{
-          position: 'absolute', bottom: 10, right: 10,
-          width: large ? 48 : 34, height: large ? 48 : 34,
-          borderRadius: 8,
-          background: 'rgba(255,255,255,0.25)',
-          backdropFilter: 'blur(8px)',
-          WebkitBackdropFilter: 'blur(8px)',
-          border: '1px solid rgba(255,255,255,0.5)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          fontSize: large ? 26 : 18,
-        }}>
-          🌹
-        </div>
+      {/* Rose badge */}
+      <div style={{
+        position: 'absolute', bottom: 10, right: 10, zIndex: 10,
+        width: large ? 48 : 34, height: large ? 48 : 34,
+        borderRadius: 8,
+        background: 'rgba(255,255,255,0.25)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        border: '1px solid rgba(255,255,255,0.5)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: large ? 26 : 18,
+      }}>
+        🌹
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- New SiteHeader — profile strip, compact-on-scroll, logo links home
- StarscapeHero — neon warp-drive canvas animation; white in light mode, dark in dark mode
- Dark mode — ThemeProvider + toggle, persists to localStorage
- New Footer — replaces Nav at bottom of all pages
- Real video thumbnails — first frame preview, muted hover play
- UX fixes — 44px touch targets, wider button gaps, clearer share icon